### PR TITLE
Nablarch 6対応

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.nablarch.tool</groupId>
   <artifactId>nablarch-statistics-report</artifactId>
-  <version>5-NEXT-SNAPSHOT</version>
+  <version>6-NEXT-SNAPSHOT</version>
 
   <scm>
     <connection>scm:git:git://github.com/nablarch/${project.artifactId}.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>com.nablarch</groupId>
     <artifactId>nablarch-parent</artifactId>
-    <version>5-NEXT-SNAPSHOT</version>
+    <version>6-NEXT-SNAPSHOT</version>
   </parent>
 
   <dependencies>


### PR DESCRIPTION
Jakarta EE には依存していなかったので、自身のバージョンとNablarchのバージョンを6-NEXT-SNAPSHOTに更新したのみ。